### PR TITLE
Allow SXG for origins with HSTS enabled. (#162)

### DIFF
--- a/cloudflare_worker/wrangler.example.toml
+++ b/cloudflare_worker/wrangler.example.toml
@@ -40,6 +40,5 @@ respond_debug_info: false
 strip_request_headers: []
 strip_response_headers:
   - set-cookie
-  - strict-transport-security
 validity_url_dirname: ".well-known/sxg-validity"
 '''

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -272,7 +272,8 @@ impl Headers {
     }
 }
 
-// These headers are always stripped before signing.
+// These headers are always stripped before signing, but preserved when serving unsigned (e.g.
+// direct or same-origin navigations, or non-prefetched subresources).
 static STRIP_RESPONSE_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     vec![
         // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#name-uncached-header-fields
@@ -282,6 +283,11 @@ static STRIP_RESPONSE_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
         "trailer",
         "transfer-encoding",
         "upgrade",
+        // Include the HSTS header from
+        // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#stateful-headers
+        // because it is an origin-wide (not URL-specific) header and origins shouldn't have to
+        // choose between HSTS and SXG. (We shouldn't create an artificial reason to disable HSTS.)
+        "strict-transport-security",
         // These headers are reserved for SXG
         ":status",
         "content-encoding",


### PR DESCRIPTION
The strict-transport-security header is disallowed in SXGs, per the
specification. In this case, rather than not sign, sxg-rs should strip the
header. Subsequent non-SXG responses (such as non-prefetched subresources or
same-origin navigations) will contain the header.